### PR TITLE
Update augmenter_training.py

### DIFF
--- a/task/augmenter_training.py
+++ b/task/augmenter_training.py
@@ -374,6 +374,12 @@ def augmenter_training(args):
             encoder_out_copy = encoder_out.clone().detach().requires_grad_(True)
             latent_out_copy, _ = model.latent_encode(encoder_out=encoder_out_copy)
             latent_out_copy.retain_grad()
+            
+            classifier_out = model.classify(latent_out=latent_out_copy)
+            cls_loss = cls_criterion(classifier_out, trg_label)
+            model.zero_grad()
+            cls_loss.backward()
+            
             latent_out_copy_grad = latent_out_copy.grad.data
 
             for i in range(20): # Need to fix


### PR DESCRIPTION
latent out 에 대해서 cls loss 를 기반으로 backward 하는 부분이 없어져서 line 378 ~ 381 추가 

깔끔한건 grad copy 이후 zero_grad 및 backward 진행하는것 같은데 순서는 상관없는것 같아서 냅뒀습니다.