### PR TITLE
Add TextAttack

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import argparse
 from task.augmenter_training import augmenter_training
 from task.augmenting import augmenting
 from task.training import training
+from task.test_textattack import test_textattack
 # from task.testing import testing
 # Utils
 from utils import str2bool, path_check, set_random_seed
@@ -30,6 +31,9 @@ def main(args):
     if args.training:
         training(args)
 
+    if args.test_textattack:
+        test_textattack(args)
+
     # Time calculate
     print(f'Done! ; {round((time.time()-total_start_time)/60, 3)}min spend')
 
@@ -41,6 +45,7 @@ if __name__=='__main__':
     parser.add_argument('--augmenter_training', action='store_true')
     parser.add_argument('--augmenting', action='store_true')
     parser.add_argument('--training', action='store_true')
+    parser.add_argument('--test_textattack', action='store_true')
     parser.add_argument('--resume', action='store_true')
     parser.add_argument('--debuging_mode', action='store_true')
     # Path setting
@@ -108,7 +113,7 @@ if __name__=='__main__':
     parser.add_argument('--cls_num_epochs', default=5, type=int,
                         help='Classifier training epochs; Default is 5')
     parser.add_argument('--training_num_epochs', default=10, type=int,
-                        help='Classifier training epochs; Default is 10')                 
+                        help='Classifier training epochs; Default is 10')
     parser.add_argument('--num_workers', default=8, type=int,
                         help='Num CPU Workers; Default is 8')
     parser.add_argument('--batch_size', default=16, type=int,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ tqdm==4.64.1
 transformers==4.12.0
 scikit-learn
 datasets
+torch-tb-profiler==0.4.1
+textattack==0.3.8 # pip install textattack[tensorflow]

--- a/task/test_textattack.py
+++ b/task/test_textattack.py
@@ -1,0 +1,91 @@
+# Import modules
+import os
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+import logging
+# Import PyTorch
+import torch
+# Import HuggingFace
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+# Import TextAttack
+from textattack.models.wrappers import HuggingFaceModelWrapper
+from textattack.attack_recipes import AttackRecipe
+from textattack import Attacker, AttackArgs
+from textattack.attack_recipes import TextFoolerJin2019, BAEGarg2019, PWWSRen2019, CLARE2020
+from textattack.datasets import HuggingFaceDataset
+# Import Custom Modules
+from utils import TqdmLoggingHandler, write_log
+from task.utils import data_load
+
+def test_textattack(args):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    #===================================#
+    #==============Logging==============#
+    #===================================#
+
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
+    handler = TqdmLoggingHandler()
+    handler.setFormatter(logging.Formatter(" %(asctime)s - %(message)s", "%Y-%m-%d %H:%M:%S"))
+    logger.addHandler(handler)
+    logger.propagate = False
+
+    write_log(logger, 'Start textattack testing!')
+
+    # Load data - even though we do not need to load data for textattack,
+    # we need to load data to get the number of labels
+    _, total_trg_list = data_load(args)
+    num_labels = len(set(total_trg_list['train']))
+
+    # Load model and tokenizer
+    tokenizer = AutoTokenizer.from_pretrained("albert-base-v2")
+    model = AutoModelForSequenceClassification.from_pretrained("albert-base-v2", num_labels=num_labels)
+
+    # Load fine-tuned model from checkpoint
+    checkpoint = torch.load(os.path.join(args.model_save_path, args.data_name, args.encoder_model_type, f'cls_training_checkpoint_seed_{args.random_seed}.pth.tar'))
+    model.load_state_dict(checkpoint['model'])
+    del checkpoint
+
+    model.to(device)
+    model.eval()
+    write_log(logger, 'Loaded fine-tuned model')
+
+    # Wrap model with textattack
+    wrapped_model = HuggingFaceModelWrapper(model, tokenizer)
+
+    # Define attack recipe
+    attack_list = [
+        TextFoolerJin2019.build(wrapped_model),
+        BAEGarg2019.build(wrapped_model),
+        PWWSRen2019.build(wrapped_model),
+    ]
+    # Define attack dataset
+    if args.data_name == 'IMDB':
+        attack_dataset = HuggingFaceDataset('imdb', split='test')
+    elif args.data_name == 'sst2':
+        attack_dataset = HuggingFaceDataset('glue', 'sst2', split='test')
+    elif args.data_name == 'cola':
+        attack_dataset = HuggingFaceDataset('glue', 'cola', split='test')
+    elif args.data_name == 'mnli':
+        attack_dataset = HuggingFaceDataset('glue', 'mnli', split='test')
+    elif args.data_name == 'mrpc':
+        attack_dataset = HuggingFaceDataset('glue', 'mrpc', split='test')
+
+    # Define attacker
+    log_path = os.path.join(args.result_path, args.data_name)
+    attacker_list = [
+        Attacker(attack_list[0], attack_dataset, AttackArgs(num_examples=100,
+                                                            log_summary_to_json=os.path.join(log_path, 'result_textfooler.json'),
+                                                            disable_stdout=True)),
+        Attacker(attack_list[1], attack_dataset, AttackArgs(num_examples=100,
+                                                            log_summary_to_json=os.path.join(log_path, 'result_bae.json'),
+                                                            disable_stdout=True)),
+        Attacker(attack_list[2], attack_dataset, AttackArgs(num_examples=100,
+                                                            log_summary_to_json=os.path.join(log_path, 'result_pwws.json'),
+                                                            disable_stdout=True)),
+    ]
+
+    write_log(logger, 'Start textattack!')
+    # Attack!
+    for each_attacker in attacker_list:
+        attack_result = each_attacker.attack_dataset()


### PR DESCRIPTION
- textattack library를 requirements.txt에 추가
- textattack은 다음과 같이 실행 가능
```shell
python main.py --test_textattack
```
- 현재 Adversarial Attack 방법:
  - [TextFooler](https://arxiv.org/pdf/1907.11932.pdf)
  - [BAE](https://arxiv.org/pdf/2004.01970v3.pdf)
  - [PWWS](https://aclanthology.org/P19-1103.pdf)
- 실행시키면 args.result_path에 각 방법별로 result가 저장됨